### PR TITLE
[Fix] SwiftUI 의 Color Extension 으로 변경

### DIFF
--- a/G-3280/Extension/Color+Extension.swift
+++ b/G-3280/Extension/Color+Extension.swift
@@ -5,36 +5,29 @@
 //  Created by ParkJunHyuk on 2023/04/30.
 //
 
-import UIKit.UIColor
+import SwiftUI
 
-extension UIColor {
-    convenience init(red: Int, green: Int, blue: Int) {
-        assert(red >= 0 && red <= 255, "Invalid red component")
-        assert(green >= 0 && green <= 255, "Invalid green component")
-        assert(blue >= 0 && blue <= 255, "Invalid blue component")
-        
-        self.init(red: CGFloat(red) / 255.0, green: CGFloat(green) / 255.0, blue: CGFloat(blue) / 255.0, alpha: 1.0)
-    }
+extension Color {
+  init(hex: String) {
+    let scanner = Scanner(string: hex)
+    _ = scanner.scanString("#")
     
-    convenience init(rgb: Int) {
-        self.init(
-            red: (rgb >> 16) & 0xFF,
-            green: (rgb >> 8) & 0xFF,
-            blue: rgb & 0xFF
-        )
-    }
+    var rgb: UInt64 = 0
+    scanner.scanHexInt64(&rgb)
+    
+    let r = Double((rgb >> 16) & 0xFF) / 255.0
+    let g = Double((rgb >>  8) & 0xFF) / 255.0
+    let b = Double((rgb >>  0) & 0xFF) / 255.0
+    self.init(red: r, green: g, blue: b)
+  }
 }
 
-extension UIColor {
-    static var customDarkGreen: UIColor {
-        return UIColor(rgb: 0x38B274)
-    }
+
+extension Color {
     
-    static var customGreen: UIColor {
-        return UIColor(rgb: 0x34E18B)
-    }
-    static var customAccentGreen: UIColor {
-        return UIColor(rgb: 0x93FB62)
-    }
+    static let customDarkGreen = Color(hex: "38B274")
+    static let customGreen = Color(hex: "34E18B")
+    static let customAccentGreen = Color(hex: "93FB62")
+    
 }
 


### PR DESCRIPTION
## ✨ 해결한 이슈 

#3 

## 🛠️ 작업내용

- [x] SwiftUI 의 Color 에 대한 Extension 으로 변경
- [x] Hex 색상 값으로도 색상 지정 가능한 로직 구현 ( # 이 값에 있어도 추가 가능 )

기존 코드는 UIKit 의 UIColor 에 대해 Extension 을 하여 3개의 색상을 추가 하였습니다
하지만 현재 프로젝트는 SwiftUI 를 사용하고 있어 UIColor 가 아닌 Color 로 변경을 하였습니다
UIKit 과 SwiftUI 를 동시에 사용하다보니 혼동이 온거 같아 앞으로는 확실하게 체크하고 작성하겠습니다

<br>

## 🖥️ 주요 코드 설명
extension 의 주요 내용은 Hex 색상 값을 사용할 수 있다는 것입니다
SwiftUI 의 Color 는 RGB 의 색상값만 사용할 수 있기 때문에 R,G,B 색상을 다 적어야 하는 번거러움이 있습니다
하지만 Hex 값은 1개의 데이터만 필요하며 편하기 때문에 다음과 같이 작성하였습니다

예시로 `customDarkGreen` 인 `#38B274` 값을 넣어보겠습니다

### '#' 을 뺀 나머지 값인 38B274 가 scanner 변수에 저장됩니다

``` swift
let scanner = Scanner(string: hex)
_ = scanner.scanString("#")
```

해당 코드는 Scanner 객체를 생성하고 hex 라는 문자열을 파싱하는 과정을 수행하게 됩니다
그 다음 scanString 메서드를 통해 '#' 문자가 있다면 제거하고 true 를 반환하고 없다면 false 를 반환하게 됩니다
'#' 문자를 제거하는 목적으로 사용했기 때문에 반환값은 필요하지 않으므로 변수를 ' _ ' 로 선언하였습니다 

<br> 

### 38B274 문자열은 10진수인 3715700 가 rgb 변수에 저장됩니다

``` swift
var rgb: UInt64 = 0
scanner.scanHexInt64(&rgb)
```

다음은 Hex 문자열을 SwiftUI 에서 Color 로 사용하기 위해선 10진수 값이 필요합니다
scanner 에 있는 문자열을 scanHexInt64 메서드를 통해 문자열에서 16진수 값을 읽어오고 다시 UInt64 타입의 10진수로 변환을 시키고 그 결과를 rgb 변수에 저장을 하게 됩니다.


<br> 

### R, G, B 에는 각 실수형 값이 저장 됩니다

``` swift
let r = Double((rgb >> 16) & 0xFF) / 255.0
let g = Double((rgb >>  8) & 0xFF) / 255.0
let b = Double((rgb >>  0) & 0xFF) / 255.0
self.init(red: r, green: g, blue: b)
```

해당 코드는 10진수를 16비트 만큼 오른쪽으로 비트 이동을 하고 0xFF 를 AND 연산자를 통해 오른쪽 8비트만 값을 추출하는 역할을 합니다
SwiftUI 의 Color 는 0부터 1까지 의 실수 값으로 색을 정하기 때문에 255.0 만큼을 나눠줍니다
Color 에 들어가는 값은 실수이기 때문에 Double 로 형변환 후 나눠주게 됩니다

<br>

#### 연산 과정

``` swift
// 3715700 2진수 
11 1000 1101 1000 1011 0100

// 16비트 만큼 오른쪽으로 비트 이동
00 0000 0000 0000 0011 1000

// 0xFF 와 And 연산

00 0000 0000 0000 0011 1000
00 0000 0000 0000 1111 1111    &
---------------------------------
00 0000 0000 0000 0011 1000 => 56

// Double 형 변환 후 255.0 로 나누기

let r = Double(56) / 255.0 => 0.2196078431372549
```

<Br>

### 비트 이동을 왜하나요?

예시로 Hex 값인 `#38B274` 를 변환하는 과정을 보여드렸습니다
여기서 맨 왼쪽 두자리 38은 Red, B2는 Green, 74는 Blue 를 의미합니다

즉, 각 자리의 값을 추출하기 위해 비트 이동을 시키고 And 연산을 통해 해당 자리를 추출하게 됩니다


<Br>

## Checklist

- [x] 빌드를 위해 SceneDelegate 수정한 것 PR로 올리지 않았는지 확인
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인