### PR TITLE
[FEAT] 로그인 화면 및 회원가입 화면 구현

### DIFF
--- a/G-3280.xcodeproj/project.pbxproj
+++ b/G-3280.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		3F3147D829FF982700BAECFC /* EvaluationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3147D729FF982700BAECFC /* EvaluationView.swift */; };
 		3F3147DA29FF983300BAECFC /* SettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3147D929FF983300BAECFC /* SettingView.swift */; };
 		3F4B9F922A04DA9300E6AD03 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 3F4B9F912A04DA9300E6AD03 /* Lottie */; };
+		3F4B9F942A04EAE300E6AD03 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9F932A04EAE300E6AD03 /* LoginView.swift */; };
+		3F4B9F962A04EB0400E6AD03 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9F952A04EB0400E6AD03 /* SignUpView.swift */; };
+		3F4B9F982A04EB3300E6AD03 /* LottieView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9F972A04EB3300E6AD03 /* LottieView.swift */; };
+		3F4B9F9C2A04EB6200E6AD03 /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4B9F9B2A04EB6200E6AD03 /* LoadingView.swift */; };
+		3F4B9F9E2A04EBB500E6AD03 /* Loading.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F4B9F9D2A04EBB500E6AD03 /* Loading.json */; };
 		3F61AAD229FE397700AABC4D /* G_3280App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAD129FE397700AABC4D /* G_3280App.swift */; };
 		3F61AAD429FE397700AABC4D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAD329FE397700AABC4D /* ContentView.swift */; };
 		3F61AAD629FE397900AABC4D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F61AAD529FE397900AABC4D /* Assets.xcassets */; };
@@ -26,6 +31,11 @@
 /* Begin PBXFileReference section */
 		3F3147D729FF982700BAECFC /* EvaluationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationView.swift; sourceTree = "<group>"; };
 		3F3147D929FF983300BAECFC /* SettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingView.swift; sourceTree = "<group>"; };
+		3F4B9F932A04EAE300E6AD03 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		3F4B9F952A04EB0400E6AD03 /* SignUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
+		3F4B9F972A04EB3300E6AD03 /* LottieView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LottieView.swift; sourceTree = "<group>"; };
+		3F4B9F9B2A04EB6200E6AD03 /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
+		3F4B9F9D2A04EBB500E6AD03 /* Loading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = Loading.json; path = ../../../../Downloads/Loading.json; sourceTree = "<group>"; };
 		3F61AACE29FE397700AABC4D /* G-3280.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "G-3280.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F61AAD129FE397700AABC4D /* G_3280App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = G_3280App.swift; sourceTree = "<group>"; };
 		3F61AAD329FE397700AABC4D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -72,6 +82,7 @@
 		3F61AAD029FE397700AABC4D /* G-3280 */ = {
 			isa = PBXGroup;
 			children = (
+				3F4B9F9D2A04EBB500E6AD03 /* Loading.json */,
 				3F73D08C2A02A37000794C96 /* Model */,
 				3F61AAF429FF7ECB00AABC4D /* View */,
 				3F61AAEC29FE484400AABC4D /* Extension */,
@@ -108,6 +119,10 @@
 				3F3147D929FF983300BAECFC /* SettingView.swift */,
 				3FF9D4972A023CA500973C55 /* CharacterCardView.swift */,
 				3F61AAF529FF7ED500AABC4D /* HomeView.swift */,
+				3F4B9F932A04EAE300E6AD03 /* LoginView.swift */,
+				3F4B9F952A04EB0400E6AD03 /* SignUpView.swift */,
+				3F4B9F972A04EB3300E6AD03 /* LottieView.swift */,
+				3F4B9F9B2A04EB6200E6AD03 /* LoadingView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -189,6 +204,7 @@
 			files = (
 				3F61AAD929FE397900AABC4D /* Preview Assets.xcassets in Resources */,
 				3F61AAD629FE397900AABC4D /* Assets.xcassets in Resources */,
+				3F4B9F9E2A04EBB500E6AD03 /* Loading.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -204,10 +220,14 @@
 				3F3147D829FF982700BAECFC /* EvaluationView.swift in Sources */,
 				3F3147DA29FF983300BAECFC /* SettingView.swift in Sources */,
 				3FF9D4982A023CA500973C55 /* CharacterCardView.swift in Sources */,
+				3F4B9F962A04EB0400E6AD03 /* SignUpView.swift in Sources */,
 				3F61AAEB29FE483900AABC4D /* Color+Extension.swift in Sources */,
 				3F73D08E2A02A38B00794C96 /* CharacterModel.swift in Sources */,
 				3F61AAD229FE397700AABC4D /* G_3280App.swift in Sources */,
+				3F4B9F942A04EAE300E6AD03 /* LoginView.swift in Sources */,
 				3F61AAF829FF7EF200AABC4D /* MissionView.swift in Sources */,
+				3F4B9F9C2A04EB6200E6AD03 /* LoadingView.swift in Sources */,
+				3F4B9F982A04EB3300E6AD03 /* LottieView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/G-3280/Extension/Color+Extension.swift
+++ b/G-3280/Extension/Color+Extension.swift
@@ -28,6 +28,8 @@ extension Color {
     static let customDarkGreen = Color(hex: "38B274")
     static let customGreen = Color(hex: "34E18B")
     static let customAccentGreen = Color(hex: "93FB62")
+    static let customGray = Color(hex: "DBD9D9")
+    static let customBackGray = Color(hex: "FBFBFD")
     
 }
 

--- a/G-3280/G_3280App.swift
+++ b/G-3280/G_3280App.swift
@@ -21,7 +21,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 struct G_3280App: App {
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            LoginView()
+//            ContentView()
         }
     }
 }

--- a/G-3280/View/LoadingView.swift
+++ b/G-3280/View/LoadingView.swift
@@ -1,0 +1,26 @@
+//
+//  LoadingView.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/05.
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        ZStack {
+            Color.customBackGray
+                .edgesIgnoringSafeArea(.all)
+            LottieView(lottieFile: "Loading", loopMode: .loop)
+                .frame(width:300, height: 300)
+                .toolbar(.hidden)
+        }
+    }
+}
+
+struct LoadingView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoadingView()
+    }
+}

--- a/G-3280/View/LoginView.swift
+++ b/G-3280/View/LoginView.swift
@@ -1,0 +1,97 @@
+//
+//  LoginView.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/05.
+//
+
+import SwiftUI
+
+struct LoginView: View {
+    
+    enum Field {
+        case userId
+        case userPw
+    }
+    
+    @State private var loginId = ""
+    @State private var loginPw = ""
+    @FocusState private var focusedField: Field?
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.customBackGray
+                    .edgesIgnoringSafeArea(.all)
+                VStack {
+                    Rectangle()
+                        .fill(Color.customGray)
+                        .frame(width: UIScreen.main.bounds.width - 90, height: 300)
+                        .padding()
+                    
+                    Spacer()
+                    
+                    VStack {
+                        TextField("아이디를 입력하세요", text: $loginId)
+                            .focused($focusedField, equals: .userId)
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 15)
+                                    .stroke(focusedField == .userId ? Color.customGreen : Color.customGray, lineWidth: 2)
+                                    .frame(width: UIScreen.main.bounds.width - 90, height: 45)
+                            )
+                            .frame(width: UIScreen.main.bounds.width - 90, height: 45)
+                            .padding(.bottom, 3)
+                        
+                        
+                        SecureField("비밀번호를 입력하세요", text: $loginPw)
+                            .focused($focusedField, equals: .userPw)
+                            .padding()
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 15)
+                                    .stroke(focusedField == .userPw ? Color.customGreen : Color.customGray, lineWidth: 2)
+                                    .frame(width: UIScreen.main.bounds.width - 90, height: 45)
+                            )
+                            .frame(width: UIScreen.main.bounds.width - 90, height: 45)
+                    }
+                    .padding(.bottom, 24)
+                    
+                    Button(action: {
+                        
+                    }){
+                        Text("로그인")
+                            .foregroundColor(.white)
+                            .fontWeight(.bold)
+                            .frame(width: UIScreen.main.bounds.width - 90, height: 53)
+                            .background(Color.customGreen)
+                            .cornerRadius(15)
+                    }
+                    .padding(.bottom, 20)
+                    
+                    HStack(spacing: 43) {
+                        NavigationLink("아이디 찾기") {
+                            EmptyView()
+                        }.foregroundColor(Color(hex: "B1B1B1"))
+                        
+                        Divider()
+                            .foregroundColor(Color(hex: "DBD9D9"))
+                            .frame(height: 27)
+                        
+                        NavigationLink("회원가입") {
+                            SignUpView()
+                        }.foregroundColor(Color(hex: "B1B1B1"))
+                    }
+                    .padding(.trailing, 10)
+                    
+                    Spacer()
+                }
+            }
+        }
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView()
+    }
+}

--- a/G-3280/View/LottieView.swift
+++ b/G-3280/View/LottieView.swift
@@ -1,0 +1,38 @@
+//
+//  LottieView.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/05.
+//
+
+import SwiftUI
+import Lottie
+
+struct LottieView: UIViewRepresentable {
+    
+    var lottieFile: String
+    var loopMode: LottieLoopMode = .playOnce
+    var animationView = LottieAnimationView()
+    
+    func makeUIView(context: UIViewRepresentableContext<LottieView>) -> UIView {
+        let view = UIView()
+        
+        animationView.animation = LottieAnimation.named(lottieFile)
+        animationView.contentMode = .scaleAspectFill
+        animationView.loopMode = loopMode
+        
+        animationView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(animationView)
+        
+        NSLayoutConstraint.activate([
+            animationView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            animationView.heightAnchor.constraint(equalTo: view.heightAnchor)
+        ])
+        
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<LottieView>) {
+        animationView.play()
+    }
+}

--- a/G-3280/View/SignUpView.swift
+++ b/G-3280/View/SignUpView.swift
@@ -1,0 +1,108 @@
+//
+//  SignUpView.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/05.
+//
+
+import SwiftUI
+
+struct SignUpView: View {
+    
+    enum Field {
+        case userId
+        case userPw
+        case userCheckPw
+        case userNickName
+    }
+    
+    @State private var signUpId = ""
+    @State private var signUpPw = ""
+    @State private var signUpCheckPw = ""
+    @State private var signUpNickName = ""
+    @FocusState private var focusedField: Field?
+    
+    var body: some View {
+        ZStack {
+            Color.customBackGray
+                .edgesIgnoringSafeArea(.all)
+            VStack {
+                VStack(alignment: .leading) {
+                    
+                    Text("아이디")
+                        .fontWeight(.bold)
+                    VStack {
+                        TextField("아이디를 입력하세요", text: $signUpId)
+                            .focused($focusedField, equals: .userId)
+                        
+                        Divider()
+                            .frame(minHeight: 2)
+                            .background(focusedField == .userId ? Color.customGreen : nil)
+                            .padding(.trailing, 34)
+                    }
+                    .padding(.bottom, 29)
+                    
+                    Text("비밀번호")
+                        .fontWeight(.bold)
+                    VStack {
+                        SecureField("비밀번호를 입력하세요", text: $signUpPw)
+                            .focused($focusedField, equals: .userPw)
+                        
+                        Divider()
+                            .frame(minHeight: 2)
+                            .background(focusedField == .userPw ? Color.customGreen : nil)
+                            .padding(.trailing, 34)
+                    }
+                    .padding(.bottom, 29)
+                    
+                    Text("비밀번호 확인")
+                        .fontWeight(.bold)
+                    VStack {
+                        SecureField("비밀번호 확인을 위해 다시 입력하세요", text: $signUpCheckPw)
+                            .focused($focusedField, equals: .userCheckPw)
+                        
+                        Divider()
+                            .frame(minHeight: 2)
+                            .background(focusedField == .userCheckPw ? Color.customGreen : nil)
+                            .padding(.trailing, 34)
+                    }
+                    .padding(.bottom, 29)
+                    
+                    Text("닉네임")
+                        .fontWeight(.bold)
+                    VStack {
+                        TextField("사용할 닉네임을 입력하세요", text: $signUpNickName)
+                            .focused($focusedField, equals: .userNickName)
+                        
+                        Divider()
+                            .frame(minHeight: 2)
+                            .background(focusedField == .userNickName ? Color.customGreen : nil)
+                            .padding(.trailing, 34)
+                    }
+                    
+                    Spacer()
+                    
+                }
+                .padding([.leading, .top], 34)
+                
+                NavigationLink {
+                    LoadingView()
+                } label: {
+                    Text("가입하기")
+                        .foregroundColor(.white)
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .frame(width: 353, height: 53)
+                        .background(Color.customGreen)
+                        .cornerRadius(15)
+                }
+            }.navigationTitle("회원가입")
+        }
+    }
+}
+
+struct SignUpView_Previews: PreviewProvider {
+    static var previews: some View {
+        SignUpView()
+    }
+}


### PR DESCRIPTION
## ✨ 해결한 이슈 
#9

## 🛠️ 작업내용
- 로그인 화면 구현 ( Logo는 사각형으로 대체 )
- 회원가입 화면 구현
- 가입 시 로딩화면 구현
- Custom 색상 Extension 에 추가

|로그인|회원가입|로딩|
|-----|-----|-----|
|<img src="https://user-images.githubusercontent.com/45564605/236495212-afb4c90e-2b3a-4e8b-8677-dc66993f445f.png"/>|<img src="https://user-images.githubusercontent.com/45564605/236496670-5f826631-c30b-4eb0-a1f4-135a7a9ed485.png"/>|<img src="https://user-images.githubusercontent.com/45564605/236495283-483051ec-948f-4c17-aedf-753f41682dde.png">|

## 📋 추후 진행 상황
- Firebase 를 이용하여 로그인 기능 구현하기

## 📌 리뷰 포인트
- Hi-Fi 와 동일하게 구현 되어 있는지 확인 부탁드립니다

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
