### PR TITLE
[FEAT] Firebase Auth 로그인 기능 구현

### DIFF
--- a/G-3280.xcodeproj/project.pbxproj
+++ b/G-3280.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		3F61AAF629FF7ED500AABC4D /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAF529FF7ED500AABC4D /* HomeView.swift */; };
 		3F61AAF829FF7EF200AABC4D /* MissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAF729FF7EF200AABC4D /* MissionView.swift */; };
 		3F73D08E2A02A38B00794C96 /* CharacterModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F73D08D2A02A38B00794C96 /* CharacterModel.swift */; };
+		3F7C968D2A0790F100C10436 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3F7C968C2A0790F100C10436 /* GoogleService-Info.plist */; };
+		3F7C968F2A07A80500C10436 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C968E2A07A80500C10436 /* AuthViewModel.swift */; };
+		3F7C96932A07E56F00C10436 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96922A07E56F00C10436 /* MainView.swift */; };
 		3FF9D4982A023CA500973C55 /* CharacterCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF9D4972A023CA500973C55 /* CharacterCardView.swift */; };
 /* End PBXBuildFile section */
 
@@ -41,11 +44,13 @@
 		3F61AAD329FE397700AABC4D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		3F61AAD529FE397900AABC4D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3F61AAD829FE397900AABC4D /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		3F61AAE129FE3AE100AABC4D /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3F61AAEA29FE483900AABC4D /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
 		3F61AAF529FF7ED500AABC4D /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		3F61AAF729FF7EF200AABC4D /* MissionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionView.swift; sourceTree = "<group>"; };
 		3F73D08D2A02A38B00794C96 /* CharacterModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterModel.swift; sourceTree = "<group>"; };
+		3F7C968C2A0790F100C10436 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		3F7C968E2A07A80500C10436 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		3F7C96922A07E56F00C10436 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		3FF9D4972A023CA500973C55 /* CharacterCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -82,14 +87,15 @@
 		3F61AAD029FE397700AABC4D /* G-3280 */ = {
 			isa = PBXGroup;
 			children = (
-				3F4B9F9D2A04EBB500E6AD03 /* Loading.json */,
+				3F7C968C2A0790F100C10436 /* GoogleService-Info.plist */,
+				3F7C96892A077D7200C10436 /* ViewModel */,
 				3F73D08C2A02A37000794C96 /* Model */,
 				3F61AAF429FF7ECB00AABC4D /* View */,
 				3F61AAEC29FE484400AABC4D /* Extension */,
-				3F61AAE129FE3AE100AABC4D /* GoogleService-Info.plist */,
 				3F61AAD129FE397700AABC4D /* G_3280App.swift */,
 				3F61AAD329FE397700AABC4D /* ContentView.swift */,
 				3F61AAD529FE397900AABC4D /* Assets.xcassets */,
+				3F4B9F9D2A04EBB500E6AD03 /* Loading.json */,
 				3F61AAD729FE397900AABC4D /* Preview Content */,
 			);
 			path = "G-3280";
@@ -123,6 +129,7 @@
 				3F4B9F952A04EB0400E6AD03 /* SignUpView.swift */,
 				3F4B9F972A04EB3300E6AD03 /* LottieView.swift */,
 				3F4B9F9B2A04EB6200E6AD03 /* LoadingView.swift */,
+				3F7C96922A07E56F00C10436 /* MainView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -133,6 +140,14 @@
 				3F73D08D2A02A38B00794C96 /* CharacterModel.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		3F7C96892A077D7200C10436 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				3F7C968E2A07A80500C10436 /* AuthViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -203,6 +218,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F61AAD929FE397900AABC4D /* Preview Assets.xcassets in Resources */,
+				3F7C968D2A0790F100C10436 /* GoogleService-Info.plist in Resources */,
 				3F61AAD629FE397900AABC4D /* Assets.xcassets in Resources */,
 				3F4B9F9E2A04EBB500E6AD03 /* Loading.json in Resources */,
 			);
@@ -221,12 +237,14 @@
 				3F3147DA29FF983300BAECFC /* SettingView.swift in Sources */,
 				3FF9D4982A023CA500973C55 /* CharacterCardView.swift in Sources */,
 				3F4B9F962A04EB0400E6AD03 /* SignUpView.swift in Sources */,
+				3F7C968F2A07A80500C10436 /* AuthViewModel.swift in Sources */,
 				3F61AAEB29FE483900AABC4D /* Color+Extension.swift in Sources */,
 				3F73D08E2A02A38B00794C96 /* CharacterModel.swift in Sources */,
 				3F61AAD229FE397700AABC4D /* G_3280App.swift in Sources */,
 				3F4B9F942A04EAE300E6AD03 /* LoginView.swift in Sources */,
 				3F61AAF829FF7EF200AABC4D /* MissionView.swift in Sources */,
 				3F4B9F9C2A04EB6200E6AD03 /* LoadingView.swift in Sources */,
+				3F7C96932A07E56F00C10436 /* MainView.swift in Sources */,
 				3F4B9F982A04EB3300E6AD03 /* LottieView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/G-3280/ContentView.swift
+++ b/G-3280/ContentView.swift
@@ -6,47 +6,29 @@
 //
 
 import SwiftUI
+import FirebaseAuth
 
 struct ContentView: View {
-    
-    @State private var selectedTab = 0
-    let unselectedColor = Color(hex: "B1B1B1")
+   
+//    @StateObject var viewModel = AuthViewModel()
+    @EnvironmentObject var viewModel : AuthViewModel
     
     var body: some View {
-        TabView(selection: $selectedTab){
-            HomeView()
-                .tabItem {
-                    selectedTab == 0 ? Image("homeFill") : Image("home")
-                    Text("홈")
-                }
-                .tag(0)
-            
-            MissionView()
-                .tabItem {
-                    selectedTab == 1 ? Image("missionFill") : Image("mission")
-                    Text("미션")
-                }
-                .tag(1)
-            
-            EvaluationView()
-                .tabItem {
-                    selectedTab == 2 ? Image("evaluationFill") : Image("evaluation")
-                    Text("평가")
-                }
-                .tag(2)
-            
-            SettingView()
-                .tabItem {
-                    selectedTab == 3 ? Image("settingFill") : Image("setting")
-                    Text("더보기")
-                }
-                .tag(3)
+        VStack{
+            if viewModel.isLoggedIn {
+                MainView()
+            } else {
+                LoginView()
+                    .onAppear{
+                        print("Login")
+                    }
+            }
         }
-        .tint(.customDarkGreen)
-
-    }
-    init() {
-        UITabBar.appearance().unselectedItemTintColor = UIColor(unselectedColor)
+        .onAppear {
+            if Auth.auth().currentUser != nil && Auth.auth().currentUser?.uid == viewModel.userUid {
+                viewModel.isLoggedIn = true
+            }
+        }
     }
 }
 

--- a/G-3280/G_3280App.swift
+++ b/G-3280/G_3280App.swift
@@ -8,21 +8,28 @@
 import SwiftUI
 import FirebaseCore
 
-class AppDelegate: NSObject, UIApplicationDelegate {
-  func application(_ application: UIApplication,
-       didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    FirebaseApp.configure()
-
-    return true
-  }
-}
+//class AppDelegate: NSObject, UIApplicationDelegate {
+//  func application(_ application: UIApplication,
+//       didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+//    FirebaseApp.configure()
+//
+//    return true
+//  }
+//}
 
 @main
 struct G_3280App: App {
+    
+    init() {
+        FirebaseApp.configure()
+    }
+    
+//    @StateObject private var viewModel = AuthViewModel()
+    
     var body: some Scene {
         WindowGroup {
-            LoginView()
-//            ContentView()
+            ContentView()
+//                .environmentObject(viewModel)
         }
     }
 }

--- a/G-3280/G_3280App.swift
+++ b/G-3280/G_3280App.swift
@@ -24,12 +24,12 @@ struct G_3280App: App {
         FirebaseApp.configure()
     }
     
-//    @StateObject private var viewModel = AuthViewModel()
+    @StateObject private var viewModel = AuthViewModel()
     
     var body: some Scene {
         WindowGroup {
             ContentView()
-//                .environmentObject(viewModel)
+                .environmentObject(viewModel)
         }
     }
 }

--- a/G-3280/View/LoginView.swift
+++ b/G-3280/View/LoginView.swift
@@ -17,6 +17,9 @@ struct LoginView: View {
     @State private var loginId = ""
     @State private var loginPw = ""
     @FocusState private var focusedField: Field?
+    @State private var isLogin = false
+    
+    @StateObject private var authViewModel: AuthViewModel = AuthViewModel()
     
     var body: some View {
         NavigationStack {
@@ -57,7 +60,9 @@ struct LoginView: View {
                     .padding(.bottom, 24)
                     
                     Button(action: {
-                        
+                        Task {
+                            await authViewModel.loginFirebase(email: loginId, password: loginPw)
+                        }
                     }){
                         Text("로그인")
                             .foregroundColor(.white)

--- a/G-3280/View/LoginView.swift
+++ b/G-3280/View/LoginView.swift
@@ -19,7 +19,7 @@ struct LoginView: View {
     @FocusState private var focusedField: Field?
     @State private var isLogin = false
     
-    @StateObject private var authViewModel: AuthViewModel = AuthViewModel()
+    @EnvironmentObject var authViewModel : AuthViewModel
     
     var body: some View {
         NavigationStack {

--- a/G-3280/View/MainView.swift
+++ b/G-3280/View/MainView.swift
@@ -1,0 +1,60 @@
+//
+//  MainView.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/07.
+//
+
+import SwiftUI
+
+struct MainView: View {
+    @State private var selectedTab = 0
+    let unselectedColor = Color(hex: "B1B1B1")
+    
+    @EnvironmentObject var viewModel : AuthViewModel
+    
+    var body: some View {
+        NavigationStack{
+            TabView(selection: $selectedTab){
+                HomeView()
+                    .tabItem {
+                        selectedTab == 0 ? Image("homeFill") : Image("home")
+                        Text("홈")
+                    }
+                    .tag(0)
+                
+                MissionView()
+                    .tabItem {
+                        selectedTab == 1 ? Image("missionFill") : Image("mission")
+                        Text("미션")
+                    }
+                    .tag(1)
+                
+                EvaluationView()
+                    .tabItem {
+                        selectedTab == 2 ? Image("evaluationFill") : Image("evaluation")
+                        Text("평가")
+                    }
+                    .tag(2)
+                
+                SettingView()
+                    .tabItem {
+                        selectedTab == 3 ? Image("settingFill") : Image("setting")
+                        Text("더보기")
+                    }
+                    .tag(3)
+            }
+            .tint(.customDarkGreen)
+        }
+
+    }
+    init() {
+        UITabBar.appearance().unselectedItemTintColor = UIColor(unselectedColor)
+    }
+}
+
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView()
+    }
+}

--- a/G-3280/View/SettingView.swift
+++ b/G-3280/View/SettingView.swift
@@ -8,8 +8,26 @@
 import SwiftUI
 
 struct SettingView: View {
+    
+    @EnvironmentObject var viewModel: AuthViewModel
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack {
+            
+        }.toolbar {
+            Text("\(viewModel.email) 님")
+
+            Spacer()
+
+            Button("로그아웃") {
+                Task {
+                    await viewModel.logoutFirebase()
+                }
+            }
+        }
+        .onAppear {
+            print(viewModel.isLoggedIn)
+        }
     }
 }
 

--- a/G-3280/ViewModel/AuthViewModel.swift
+++ b/G-3280/ViewModel/AuthViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  LoginViewModel.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/07.
+//
+
+import SwiftUI
+import Firebase
+
+class AuthViewModel: ObservableObject {
+    
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var isLoggedIn = false
+    
+    func loginFirebase(email: String, password: String) async {
+        do {
+            try await Auth.auth().signIn(withEmail: email, password: password)
+            await MainActor.run(body: {
+                print("성공")
+                withAnimation(.easeInOut) { self.isLoggedIn = true }
+            })
+        } catch {
+            print("Failed to log in with error: \(error.localizedDescription)")
+            await MainActor.run(body: {
+                print("실패")
+                withAnimation(.easeInOut) { self.isLoggedIn = false }
+            })
+        }
+    }
+    
+}

--- a/G-3280/ViewModel/AuthViewModel.swift
+++ b/G-3280/ViewModel/AuthViewModel.swift
@@ -13,12 +13,16 @@ class AuthViewModel: ObservableObject {
     @Published var email: String = ""
     @Published var password: String = ""
     @Published var isLoggedIn = false
+    @AppStorage("user_uid") var userUid: String = ""
+    
     
     func loginFirebase(email: String, password: String) async {
         do {
-            try await Auth.auth().signIn(withEmail: email, password: password)
+            let result = try await Auth.auth().signIn(withEmail: email, password: password)
             await MainActor.run(body: {
                 print("성공")
+                self.userUid = result.user.uid
+                print(userUid)
                 withAnimation(.easeInOut) { self.isLoggedIn = true }
             })
         } catch {
@@ -29,5 +33,34 @@ class AuthViewModel: ObservableObject {
             })
         }
     }
+    
+    func logoutFirebase() async {
+        do {
+            try Auth.auth().signOut()
+            await MainActor.run(body: {
+                self.isLoggedIn = false
+            })
+        } catch {
+//            throw error
+        }
+    }
+    
+//    func loginFirebase(email: String, password: String) {
+//        Task{
+//            do {
+//                try await Auth.auth().signIn(withEmail: email, password: password)
+//                await MainActor.run(body: {
+//                    print("성공")
+//                    withAnimation(.easeInOut) { self.isLoggedIn = true }
+//                })
+//            } catch {
+//                print("Failed to log in with error: \(error.localizedDescription)")
+//                await MainActor.run(body: {
+//                    print("실패")
+//                    withAnimation(.easeInOut) { self.isLoggedIn = false }
+//                })
+//            }
+//        }
+//    }
     
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
#11 

## 🛠️ 작업내용
- Firebase Auth 를 통해 로그인, 로그아웃 기능을 구현
- 로그인이 되어 있으면 `MainView,` 로그인이 되어있지 않으면 `LoginView` 로 전환
<br>

|ScreenShot|
|------|
|![Simulator Screen Recording - iPhone 14 Pro - 2023-05-08 at 16 55 54](https://user-images.githubusercontent.com/45564605/236769688-e88f1ddb-8804-406a-891f-d8d277e63582.gif)|

<br>

### Login 로직에 대한 순서

#### 1. `currentUser` 에 회원정보 및 기기에 저장된 `uid` 값이 있는지 체크

<br>

먼저 Firebase 에 현재 로그인 되어있는 사용자가 있는지 체크하기 위해 `Auth.auth().currentUser` 를 사용합니다

해당 코드는 로그인 되어있는 사용자를 불러올 수 있는데 단점으로 로그아웃을 하지 않고 앱을 삭제해도 Firebase 에는 로그인이 되어있어 앱을 삭제하고 설치해도 자동으로 로그인이 되어있는 것으로 됩니다

이러한 현상을 방지하고자 로그인을 하게 되면 기기안에 uid 를 저장하여 더블 체크를 하고자 합니다 
한번이라도 로그인을 했다면 기기에는 uid 가 저장되므로 위의 현상을 방지할 수 있게 됩니다

즉, 현재로그인 되어있는 사용자가 있는지 있다면 기기에 저장되어있는 uid 와 일치하는지 체크를 먼저하게 됩니다

<br>

#### 2. `isLoggedIn` 변수로 로그인이 되어있는지 체크

<br>

`isLoggedIn` 변수는 `AuthViewModel` 의 프로퍼티로 로그인이 되어있는지 상태를 체크할 수 있습니다
1번 과정도 해당 변수를 통해 `MainView` 또는 `LoginView` 를 보여주게 됩니다

`AuthViewModel` 에서 `FirebaseAuth` 의 `signIn()` 메서드를 통해 로그인이 성공했다는 결과를 받으면 `isLoggedIn` 프로퍼티를 `true` 로 바꾸게 됩니다

해당 프로퍼티는 `@Pulished` 로 선언된 프로퍼티 래퍼로 값이 변경되면 해당 `ViewModel` 을 채택한 `View` 를 업데이트하게 됩니다
<br>

## 📋 추후 진행 상황
- Firebase FireStore 에 회원정보 저장하는 회원가입 기능 구현
<br>

## 📌 리뷰 포인트
- 로그인 시 화면이 MainView 로 넘어가는지 확인해주세요
- 앱을 종료해도 로그인이 되어 있는지 확인해주세요
<br>

## 📂 참고한 내용
https://firebase.google.com/docs/ios/setup?hl=ko
https://elisha0103.tistory.com/10
<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
