### PR TITLE
[FEAT] Firebase Auth 로 회원가입 인증 구현

### DIFF
--- a/G-3280.xcodeproj/project.pbxproj
+++ b/G-3280.xcodeproj/project.pbxproj
@@ -19,8 +19,6 @@
 		3F61AAD429FE397700AABC4D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAD329FE397700AABC4D /* ContentView.swift */; };
 		3F61AAD629FE397900AABC4D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F61AAD529FE397900AABC4D /* Assets.xcassets */; };
 		3F61AAD929FE397900AABC4D /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F61AAD829FE397900AABC4D /* Preview Assets.xcassets */; };
-		3F61AAE429FE3BB900AABC4D /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3F61AAE329FE3BB900AABC4D /* FirebaseAuth */; };
-		3F61AAE629FE3BB900AABC4D /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = 3F61AAE529FE3BB900AABC4D /* FirebaseDatabase */; };
 		3F61AAEB29FE483900AABC4D /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAEA29FE483900AABC4D /* Color+Extension.swift */; };
 		3F61AAF629FF7ED500AABC4D /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAF529FF7ED500AABC4D /* HomeView.swift */; };
 		3F61AAF829FF7EF200AABC4D /* MissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F61AAF729FF7EF200AABC4D /* MissionView.swift */; };
@@ -28,6 +26,13 @@
 		3F7C968D2A0790F100C10436 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3F7C968C2A0790F100C10436 /* GoogleService-Info.plist */; };
 		3F7C968F2A07A80500C10436 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C968E2A07A80500C10436 /* AuthViewModel.swift */; };
 		3F7C96932A07E56F00C10436 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96922A07E56F00C10436 /* MainView.swift */; };
+		3F7C96972A08E91C00C10436 /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96962A08E91C00C10436 /* SignUpViewModel.swift */; };
+		3F7C96992A0B35C400C10436 /* CompletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96982A0B35C400C10436 /* CompletedView.swift */; };
+		3F7C96A42A0CA8AD00C10436 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3F7C96A32A0CA8AD00C10436 /* FirebaseAuth */; };
+		3F7C96A62A0CA8AD00C10436 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = 3F7C96A52A0CA8AD00C10436 /* FirebaseFirestore */; };
+		3F7C96A82A0CA8AD00C10436 /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = 3F7C96A72A0CA8AD00C10436 /* FirebaseFirestoreCombine-Community */; };
+		3F7C96AA2A0CA8AD00C10436 /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 3F7C96A92A0CA8AD00C10436 /* FirebaseFirestoreSwift */; };
+		3F7C96AC2A0CA8AD00C10436 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3F7C96AB2A0CA8AD00C10436 /* FirebaseMessaging */; };
 		3FF9D4982A023CA500973C55 /* CharacterCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF9D4972A023CA500973C55 /* CharacterCardView.swift */; };
 /* End PBXBuildFile section */
 
@@ -51,6 +56,8 @@
 		3F7C968C2A0790F100C10436 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3F7C968E2A07A80500C10436 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		3F7C96922A07E56F00C10436 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		3F7C96962A08E91C00C10436 /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
+		3F7C96982A0B35C400C10436 /* CompletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletedView.swift; sourceTree = "<group>"; };
 		3FF9D4972A023CA500973C55 /* CharacterCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -59,9 +66,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F61AAE629FE3BB900AABC4D /* FirebaseDatabase in Frameworks */,
-				3F61AAE429FE3BB900AABC4D /* FirebaseAuth in Frameworks */,
+				3F7C96AC2A0CA8AD00C10436 /* FirebaseMessaging in Frameworks */,
+				3F7C96AA2A0CA8AD00C10436 /* FirebaseFirestoreSwift in Frameworks */,
 				3F4B9F922A04DA9300E6AD03 /* Lottie in Frameworks */,
+				3F7C96A82A0CA8AD00C10436 /* FirebaseFirestoreCombine-Community in Frameworks */,
+				3F7C96A42A0CA8AD00C10436 /* FirebaseAuth in Frameworks */,
+				3F7C96A62A0CA8AD00C10436 /* FirebaseFirestore in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,6 +140,7 @@
 				3F4B9F972A04EB3300E6AD03 /* LottieView.swift */,
 				3F4B9F9B2A04EB6200E6AD03 /* LoadingView.swift */,
 				3F7C96922A07E56F00C10436 /* MainView.swift */,
+				3F7C96982A0B35C400C10436 /* CompletedView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -146,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				3F7C968E2A07A80500C10436 /* AuthViewModel.swift */,
+				3F7C96962A08E91C00C10436 /* SignUpViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -167,9 +179,12 @@
 			);
 			name = "G-3280";
 			packageProductDependencies = (
-				3F61AAE329FE3BB900AABC4D /* FirebaseAuth */,
-				3F61AAE529FE3BB900AABC4D /* FirebaseDatabase */,
 				3F4B9F912A04DA9300E6AD03 /* Lottie */,
+				3F7C96A32A0CA8AD00C10436 /* FirebaseAuth */,
+				3F7C96A52A0CA8AD00C10436 /* FirebaseFirestore */,
+				3F7C96A72A0CA8AD00C10436 /* FirebaseFirestoreCombine-Community */,
+				3F7C96A92A0CA8AD00C10436 /* FirebaseFirestoreSwift */,
+				3F7C96AB2A0CA8AD00C10436 /* FirebaseMessaging */,
 			);
 			productName = "G-3280";
 			productReference = 3F61AACE29FE397700AABC4D /* G-3280.app */;
@@ -200,8 +215,8 @@
 			);
 			mainGroup = 3F61AAC529FE397700AABC4D;
 			packageReferences = (
-				3F61AAE229FE3BB900AABC4D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				3F4B9F902A04DA9300E6AD03 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 3F61AACF29FE397700AABC4D /* Products */;
 			projectDirPath = "";
@@ -233,6 +248,8 @@
 			files = (
 				3F61AAD429FE397700AABC4D /* ContentView.swift in Sources */,
 				3F61AAF629FF7ED500AABC4D /* HomeView.swift in Sources */,
+				3F7C96992A0B35C400C10436 /* CompletedView.swift in Sources */,
+				3F7C96972A08E91C00C10436 /* SignUpViewModel.swift in Sources */,
 				3F3147D829FF982700BAECFC /* EvaluationView.swift in Sources */,
 				3F3147DA29FF983300BAECFC /* SettingView.swift in Sources */,
 				3FF9D4982A023CA500973C55 /* CharacterCardView.swift in Sources */,
@@ -456,9 +473,9 @@
 				minimumVersion = 4.0.0;
 			};
 		};
-		3F61AAE229FE3BB900AABC4D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 10.0.0;
@@ -472,15 +489,30 @@
 			package = 3F4B9F902A04DA9300E6AD03 /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
-		3F61AAE329FE3BB900AABC4D /* FirebaseAuth */ = {
+		3F7C96A32A0CA8AD00C10436 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F61AAE229FE3BB900AABC4D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
 		};
-		3F61AAE529FE3BB900AABC4D /* FirebaseDatabase */ = {
+		3F7C96A52A0CA8AD00C10436 /* FirebaseFirestore */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F61AAE229FE3BB900AABC4D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseDatabase;
+			package = 3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+		3F7C96A72A0CA8AD00C10436 /* FirebaseFirestoreCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFirestoreCombine-Community";
+		};
+		3F7C96A92A0CA8AD00C10436 /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
+		};
+		3F7C96AB2A0CA8AD00C10436 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F7C96A22A0CA8AD00C10436 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/G-3280.xcodeproj/xcuserdata/parkjunhyuk.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/G-3280.xcodeproj/xcuserdata/parkjunhyuk.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,28 +7,49 @@
 		<key>G-3280.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>Promises (Playground) 1.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>3</integer>
 		</dict>
 		<key>Promises (Playground) 2.xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>4</integer>
+		</dict>
+		<key>Promises (Playground) 3.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>Promises (Playground) 4.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>5</integer>
+		</dict>
+		<key>Promises (Playground) 5.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>6</integer>
 		</dict>
 		<key>Promises (Playground).xcscheme</key>
 		<dict>
 			<key>isShown</key>
 			<false/>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>

--- a/G-3280/ContentView.swift
+++ b/G-3280/ContentView.swift
@@ -9,19 +9,18 @@ import SwiftUI
 import FirebaseAuth
 
 struct ContentView: View {
-   
-//    @StateObject var viewModel = AuthViewModel()
     @EnvironmentObject var viewModel : AuthViewModel
     
     var body: some View {
-        VStack{
-            if viewModel.isLoggedIn {
-                MainView()
-            } else {
-                LoginView()
-                    .onAppear{
-                        print("Login")
-                    }
+        ZStack {
+            Color.customBackGray
+                .edgesIgnoringSafeArea(.all)
+            VStack{
+                if viewModel.isLoggedIn {
+                    MainView()
+                } else {
+                    LoginView()
+                }
             }
         }
         .onAppear {

--- a/G-3280/View/CompletedView.swift
+++ b/G-3280/View/CompletedView.swift
@@ -1,0 +1,51 @@
+//
+//  CompletedView.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/10.
+//
+
+import SwiftUI
+
+struct CompletedView: View {
+    
+    @Binding var stack: [Int]
+    
+    var body: some View {
+        VStack{
+            Text("회원가입을")
+                .font(.title2)
+                .fontWeight(.bold)
+                .padding(.top, 210)
+
+            Text("완료했습니다!")
+                .font(.title2)
+                .fontWeight(.bold)
+                .padding(.top, -5)
+            
+            Spacer()
+            
+            Button {
+                stack = .init()
+            } label: {
+                Text("로그인 하러가기")
+                    .foregroundColor(.white)
+                    .font(.title3)
+                    .fontWeight(.bold)
+                    .frame(width: 353, height: 53)
+                    .background(Color.customGreen)
+                    .cornerRadius(15)
+            }
+            .padding(.bottom, 20)
+        }
+        .toolbar(.hidden)
+    }
+}
+
+//struct CompletedView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CompletedView()
+//    }
+//}
+
+

--- a/G-3280/View/LoginView.swift
+++ b/G-3280/View/LoginView.swift
@@ -17,12 +17,12 @@ struct LoginView: View {
     @State private var loginId = ""
     @State private var loginPw = ""
     @FocusState private var focusedField: Field?
-    @State private var isLogin = false
+    @State var stack: [Int] = []
     
     @EnvironmentObject var authViewModel : AuthViewModel
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $stack) {
             ZStack {
                 Color.customBackGray
                     .edgesIgnoringSafeArea(.all)
@@ -82,9 +82,15 @@ struct LoginView: View {
                             .foregroundColor(Color(hex: "DBD9D9"))
                             .frame(height: 27)
                         
-                        NavigationLink("회원가입") {
-                            SignUpView()
-                        }.foregroundColor(Color(hex: "B1B1B1"))
+                        Button {
+                            stack.append(1)
+                        } label: {
+                            Text("회원가입")
+                                .foregroundColor(Color(hex: "B1B1B1"))
+                        }
+                        .navigationDestination(for: Int.self) { int in
+                            SignUpView(stack: $stack)
+                        }
                     }
                     .padding(.trailing, 10)
                     

--- a/G-3280/View/SignUpView.swift
+++ b/G-3280/View/SignUpView.swift
@@ -16,93 +16,105 @@ struct SignUpView: View {
         case userNickName
     }
     
-    @State private var signUpId = ""
-    @State private var signUpPw = ""
-    @State private var signUpCheckPw = ""
-    @State private var signUpNickName = ""
+    @StateObject private var viewModel = SignUpViewModel()
     @FocusState private var focusedField: Field?
+    @Binding var stack: [Int]
     
     var body: some View {
-        ZStack {
-            Color.customBackGray
-                .edgesIgnoringSafeArea(.all)
-            VStack {
-                VStack(alignment: .leading) {
-                    
-                    Text("아이디")
-                        .fontWeight(.bold)
-                    VStack {
-                        TextField("아이디를 입력하세요", text: $signUpId)
-                            .focused($focusedField, equals: .userId)
-                        
-                        Divider()
-                            .frame(minHeight: 2)
-                            .background(focusedField == .userId ? Color.customGreen : nil)
-                            .padding(.trailing, 34)
-                    }
-                    .padding(.bottom, 29)
-                    
-                    Text("비밀번호")
-                        .fontWeight(.bold)
-                    VStack {
-                        SecureField("비밀번호를 입력하세요", text: $signUpPw)
-                            .focused($focusedField, equals: .userPw)
-                        
-                        Divider()
-                            .frame(minHeight: 2)
-                            .background(focusedField == .userPw ? Color.customGreen : nil)
-                            .padding(.trailing, 34)
-                    }
-                    .padding(.bottom, 29)
-                    
-                    Text("비밀번호 확인")
-                        .fontWeight(.bold)
-                    VStack {
-                        SecureField("비밀번호 확인을 위해 다시 입력하세요", text: $signUpCheckPw)
-                            .focused($focusedField, equals: .userCheckPw)
-                        
-                        Divider()
-                            .frame(minHeight: 2)
-                            .background(focusedField == .userCheckPw ? Color.customGreen : nil)
-                            .padding(.trailing, 34)
-                    }
-                    .padding(.bottom, 29)
-                    
-                    Text("닉네임")
-                        .fontWeight(.bold)
-                    VStack {
-                        TextField("사용할 닉네임을 입력하세요", text: $signUpNickName)
-                            .focused($focusedField, equals: .userNickName)
-                        
-                        Divider()
-                            .frame(minHeight: 2)
-                            .background(focusedField == .userNickName ? Color.customGreen : nil)
-                            .padding(.trailing, 34)
-                    }
-                    
-                    Spacer()
-                    
-                }
-                .padding([.leading, .top], 34)
-                
-                NavigationLink {
-                    LoadingView()
-                } label: {
-                    Text("가입하기")
-                        .foregroundColor(.white)
-                        .font(.title3)
-                        .fontWeight(.bold)
-                        .frame(width: 353, height: 53)
-                        .background(Color.customGreen)
-                        .cornerRadius(15)
-                }
-            }.navigationTitle("회원가입")
+        switch viewModel.signUpStatus {
+            case .signUp: content
+            case .isLoading: LoadingView()
+                .transition(.move(edge: .trailing))
+            case .isSignUpCompleted: CompletedView(stack: $stack)
         }
     }
+    
+    @ViewBuilder
+        private var content: some View {
+            ZStack {
+                Color.customBackGray
+                    .edgesIgnoringSafeArea(.all)
+                VStack {
+                    VStack(alignment: .leading) {
+                        
+                        Text("아이디")
+                            .fontWeight(.bold)
+                        VStack {
+                            TextField("아이디를 입력하세요", text: $viewModel.email)
+                                .focused($focusedField, equals: .userId)
+                            
+                            Divider()
+                                .frame(minHeight: 2)
+                                .background(focusedField == .userId ? Color.customGreen : nil)
+                                .padding(.trailing, 34)
+                        }
+                        .padding(.bottom, 29)
+                        
+                        Text("비밀번호")
+                            .fontWeight(.bold)
+                        VStack {
+                            SecureField("비밀번호를 입력하세요", text: $viewModel.password)
+                                .focused($focusedField, equals: .userPw)
+                            
+                            Divider()
+                                .frame(minHeight: 2)
+                                .background(focusedField == .userPw ? Color.customGreen : nil)
+                                .padding(.trailing, 34)
+                        }
+                        .padding(.bottom, 29)
+                        
+                        Text("비밀번호 확인")
+                            .fontWeight(.bold)
+                        VStack {
+                            SecureField("비밀번호 확인을 위해 다시 입력하세요", text: $viewModel.confirmPassword)
+                                .focused($focusedField, equals: .userCheckPw)
+                            
+                            Divider()
+                                .frame(minHeight: 2)
+                                .background(focusedField == .userCheckPw ? Color.customGreen : nil)
+                                .padding(.trailing, 34)
+                        }
+                        .padding(.bottom, 29)
+                        
+                        Text("닉네임")
+                            .fontWeight(.bold)
+                        VStack {
+                            TextField("사용할 닉네임을 입력하세요", text: $viewModel.nickname)
+                                .focused($focusedField, equals: .userNickName)
+                            
+                            Divider()
+                                .frame(minHeight: 2)
+                                .background(focusedField == .userNickName ? Color.customGreen : nil)
+                                .padding(.trailing, 34)
+                        }
+                        
+                        Spacer()
+                        
+                    }
+                    .padding([.leading, .top], 34)
+                    
+                    Button(action: {
+                        Task {
+                            await viewModel.signUp()
+                        }
+                    }){
+                        Text("가입하기")
+                            .foregroundColor(.white)
+                            .font(.title3)
+                            .fontWeight(.bold)
+                            .frame(width: 353, height: 53)
+                            .background(Color.customGreen)
+                            .cornerRadius(15)
+                    }
+                    .padding(.bottom, 20)
+                }
+                .navigationTitle("회원가입")
+            }
+        }
 }
 
-struct SignUpView_Previews: PreviewProvider {
-    static var previews: some View {
-        SignUpView()
-    }
-}
+//struct SignUpView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SignUpView()
+//    }
+//}

--- a/G-3280/ViewModel/AuthViewModel.swift
+++ b/G-3280/ViewModel/AuthViewModel.swift
@@ -41,26 +41,7 @@ class AuthViewModel: ObservableObject {
                 self.isLoggedIn = false
             })
         } catch {
-//            throw error
+            print("Failed to log in with error: \(error.localizedDescription)")
         }
     }
-    
-//    func loginFirebase(email: String, password: String) {
-//        Task{
-//            do {
-//                try await Auth.auth().signIn(withEmail: email, password: password)
-//                await MainActor.run(body: {
-//                    print("성공")
-//                    withAnimation(.easeInOut) { self.isLoggedIn = true }
-//                })
-//            } catch {
-//                print("Failed to log in with error: \(error.localizedDescription)")
-//                await MainActor.run(body: {
-//                    print("실패")
-//                    withAnimation(.easeInOut) { self.isLoggedIn = false }
-//                })
-//            }
-//        }
-//    }
-    
 }

--- a/G-3280/ViewModel/SignUpViewModel.swift
+++ b/G-3280/ViewModel/SignUpViewModel.swift
@@ -1,0 +1,49 @@
+//
+//  SignUpViewModel.swift
+//  G-3280
+//
+//  Created by ParkJunHyuk on 2023/05/08.
+//
+
+import SwiftUI
+import FirebaseAuth
+
+class SignUpViewModel: ObservableObject {
+    
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var confirmPassword: String = ""
+    @Published var nickname: String = ""
+    @Published var errorMessage: String?
+    @Published var signUpStatus: status = .signUp
+    
+    enum status {
+        case signUp
+        case isLoading
+        case isSignUpCompleted
+    }
+
+    func signUp() async {
+        do {
+            await MainActor.run(body: {
+                withAnimation(Animation.easeIn) {
+                    self.signUpStatus = .isLoading
+                }
+            })
+            
+            let result = try await Auth.auth().createUser(withEmail: email, password: password)
+            
+            print(result.user)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                self.signUpStatus = .isSignUpCompleted
+            }
+        } catch {
+            print("Failed to log in with error: \(error.localizedDescription)")
+            
+            await MainActor.run(body: {
+                self.signUpStatus = .signUp
+            })
+        }
+    }
+}


### PR DESCRIPTION
## ✨ 해결한 이슈 
#13

<br>

## 🛠️ 작업내용
- 비동기 처리를 통해 Firebase Auth 에 회원가입 정보 작성
- 회원가입 로직 상태 변환을 통해 View 전환

<br>

### ❗️어려웠던 점

1. 비동기 처리를 통해 회원가입 완료 시점 파악하기 

Firebase 에 유저 인증을 위한 정보를 보내야 하기 때문에 네트워크 처리가 필요합니다
네트워크 처리는 주로 비동기로 처리하게 되고 Swift 에서 기존에 completion handler 를 주로 사용했었습니다

completion handler 의 사용으로 인해 콜백이 많아지게 되고 들여쓰기로 인해 가독성이 안좋아지게 됩니다
또한 오류 처리에 대한 구문을 작성하지 않더라도 구문 오류를 발생시키지 않는 단점이 있습니다

위와 같은 이유를 통해  Swift 5.5 부터 지원하는 Async / await 을 채택하여 더욱 깔끔해진 코드 가독성과 함께 오류처리를 잘할 수 있게 되었습니다

<br>

2. 상태 변환을 통한 View 전환하기

회원가입에 관련된 View 들을 전환할 때 어떠한 방식으로 처리를 할지 고민이 많았습니다

첫번째로는 ViewModel 의 프로퍼티를 통해 상태 변환을 시켜주는 것입니다

회원가입에서 필요한 상태는 총 3개 ( 회원 가입 중, 로딩 중, 완료 ) 로 설정하였습니다
결과적으로 ViewModel 에는 3개의 Bool 형 프로퍼티가 생기게 되었고 View 에는 `if - else` 구문으로 View 를 전환 시키게 되었습니다

코드의 가독성이 좋지 않아 직관적이지 않았고 if 문을 사용하게 되므로 어떤 상태에서 어떤 블럭에서 처리가 되는지 한번에 알수 없는 단점이 있었습니다

<br>

두번째로는 ViewModel 에 enum 으로 상태 변환을 시켜주는 것입니다

``` swift
enum status {
        case signUp
        case isLoading
        case isSignUpCompleted
}

switch viewModel.signUpStatus {
        case .signUp: content
        case .isLoading: LoadingView()
        case .isSignUpCompleted: CompletedView(stack: $stack)
}
```

다음과 같이 enum 을 설정하였고 View 에서는 switch - case 구문을 통해 해당 상태에 맞는 View 를 보여줄수 있도록 설계하였습니다
기존의 if 문 보다 더욱 가독성이 좋아졌고 어떤 상태인지 정확히 파악을 할 수 있게 되었습니다

<br>

## 📋 추후 진행 상황
- FireStore 에 회원 정보 저장 로직 구현

<br>

## 📌 리뷰 포인트
- 회원가입 시 각 화면이 제대로 동작하는지 확인부탁드립니다

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
