### PR TITLE
[FEAT] Firestore 에 User 정보 저장하기

### DIFF
--- a/G-3280/ContentView.swift
+++ b/G-3280/ContentView.swift
@@ -12,23 +12,23 @@ struct ContentView: View {
     @EnvironmentObject var viewModel : AuthViewModel
     
     var body: some View {
-        MainView()
-//        ZStack {
-//            Color.customBackGray
-//                .edgesIgnoringSafeArea(.all)
-//            VStack{
-//                if viewModel.isLoggedIn {
-//                    MainView()
-//                } else {
-//                    LoginView()
-//                }
-//            }
-//        }
-//        .onAppear {
-//            if Auth.auth().currentUser != nil && Auth.auth().currentUser?.uid == viewModel.userUid {
-//                viewModel.isLoggedIn = true
-//            }
-//        }
+//        MainView()
+        ZStack {
+            Color.customBackGray
+                .edgesIgnoringSafeArea(.all)
+            VStack{
+                if viewModel.isLoggedIn {
+                    MainView()
+                } else {
+                    LoginView()
+                }
+            }
+        }
+        .onAppear {
+            if Auth.auth().currentUser != nil && Auth.auth().currentUser?.uid == viewModel.userUid {
+                viewModel.isLoggedIn = true
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## ✨ 해결한 이슈 
#15

<br>

## 🛠️ 작업내용
- Firestore 에 유저 정보를 저장하는 기능 구현
- users 라는 컬렉션 에 uid 도큐먼트 안에 아래 user data 를 저장 
- uid, email, nickname, completedMission, completedCard, completedEvaluation 를 저장

<br>

## 📋 추후 진행 상황
- 유저 정보를 불러와 homeView 및 MoreInfoView 에 필요한 정보를 출력하는 기능을 구현

<br>

## 📌 리뷰 포인트
- 회원가입 하고 로그인이 잘 되는지 확인해주세요!

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
