### PR TITLE
[FEAT] 현재 월, 일 출력 및 선택한 옵션에 따른 mission 출력 

### DIFF
--- a/G-3280/Model/MissionModel.swift
+++ b/G-3280/Model/MissionModel.swift
@@ -8,19 +8,43 @@
 import Foundation
 
 enum missionInfo: String, CaseIterable {
-    case today = "일일미션"
-    case Week = "주간미션"
+    case today = "today"
+    case week = "week"
+    
+    func stringValue() -> String {
+        switch self {
+        case .today:
+            return "일일미션"
+        case .week:
+            return "주간미션"
+        }
+    }
 }
 
 enum missionCategory: String, CaseIterable {
-    case none = "All"
-    case water = "물 아껴쓰기"
-    case food = "음식물 쓰래기 줄이기"
-    case electricity = "전기 아껴쓰기"
-    case recycle = "분리수거 잘하기"
+    case none = "none"
+    case water = "water"
+    case food = "food"
+    case electricity = "electricity"
+    case recycle = "recycle"
+    
+    func stringValue() -> String {
+        switch self {
+        case .none:
+            return "All"
+        case .water:
+            return "물 아껴쓰기"
+        case .food:
+            return "음식물 쓰래기 줄이기"
+        case .electricity:
+            return "전기 아껴쓰기"
+        case .recycle:
+            return "분리수거 잘하기"
+        }
+    }
 }
 
-struct Mission: Identifiable {
+struct Mission: Identifiable, Hashable{
     let id = UUID()
     let type: String
     let category: String
@@ -29,7 +53,7 @@ struct Mission: Identifiable {
 }
 
 let missionData: [Mission] = [Mission(type: "today", category: "water", name: "양치컵에 물을 받아서 양치해요!", isCompleted: true),
-                              Mission(type: "weak", category: "food", name: "양치컵에 물을 받아서 양치해요!", isCompleted: false),
+                              Mission(type: "week", category: "food", name: "양치컵에 물을 받아서 양치해요!", isCompleted: false),
                               Mission(type: "today", category: "electricity", name: "양치컵에 물을 받아서 양치해요!", isCompleted: false),
-                              Mission(type: "weak", category: "water", name: "양치컵에 물을 받아서 양치해요!", isCompleted: false),
+                              Mission(type: "week", category: "water", name: "양치컵에 물을 받아서 양치해요!", isCompleted: false),
                               Mission(type: "today", category: "food", name: "양치컵에 물을 받아서 양치해요!", isCompleted: false)]

--- a/G-3280/Model/MissionModel.swift
+++ b/G-3280/Model/MissionModel.swift
@@ -7,6 +7,19 @@
 
 import Foundation
 
+enum missionInfo: String, CaseIterable {
+    case today = "일일미션"
+    case Week = "주간미션"
+}
+
+enum missionCategory: String, CaseIterable {
+    case none = "All"
+    case water = "물 아껴쓰기"
+    case food = "음식물 쓰래기 줄이기"
+    case electricity = "전기 아껴쓰기"
+    case recycle = "분리수거 잘하기"
+}
+
 struct Mission: Identifiable {
     let id = UUID()
     let type: String

--- a/G-3280/View/MissionView.swift
+++ b/G-3280/View/MissionView.swift
@@ -14,6 +14,8 @@ struct MissionView: View {
     @Namespace private var missionAnimation
     @Namespace private var missionCategoryAnimation
     
+    @State private var currentTime: String = ""
+    
     var body: some View {
         ZStack{
             Color.customBackGray
@@ -63,8 +65,11 @@ struct MissionView: View {
             }
             .padding(.bottom, 1)
             
-            Text("4월 26일")
+            Text(currentTime)
                 .foregroundColor(.customMissionBarGray)
+                .onAppear {
+                    currentTime = getCurrentTime()
+                }
         }
     }
     
@@ -138,15 +143,10 @@ struct MissionView_Previews: PreviewProvider {
     }
 }
 
-enum missionInfo: String, CaseIterable {
-    case today = "일일미션"
-    case Week = "주간미션"
-}
-
-enum missionCategory: String, CaseIterable {
-    case none = "All"
-    case water = "물 아껴쓰기"
-    case food = "음식물 쓰래기 줄이기"
-    case electricity = "전기 아껴쓰기"
-    case recycle = "분리수거 잘하기"
+func getCurrentTime() -> String {
+    let nowDate = Date()
+    var formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "ko")
+    formatter.dateFormat = "M월 dd일"
+    return formatter.string(from: Date())
 }

--- a/G-3280/View/MissionView.swift
+++ b/G-3280/View/MissionView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct MissionView: View {
     
+    @StateObject var missionViewModel = MissionViewModel()
+    
     @State private var selectedMission: missionInfo = .today
     @State private var selectedMissionCategory: missionCategory = .none
     @Namespace private var missionAnimation
@@ -31,7 +33,7 @@ struct MissionView: View {
                 .padding(.horizontal, 28)
                 .padding(.top, 20)
                 
-                List(missionData) { data in
+                List(missionViewModel.nowMission) { data in
                     MissionCardView(cardData: data)
                         .padding(.horizontal, 28)
                         .listRowBackground(Color.clear)
@@ -39,7 +41,6 @@ struct MissionView: View {
                         .shadow(color: Color.customGray ,radius: 5)
                 }
                 .listStyle(.plain)
-                
             }
         }
             
@@ -68,7 +69,7 @@ struct MissionView: View {
             Text(currentTime)
                 .foregroundColor(.customMissionBarGray)
                 .onAppear {
-                    currentTime = getCurrentTime()
+                    currentTime = missionViewModel.getCurrentTime()
                 }
         }
     }
@@ -85,7 +86,7 @@ struct MissionView: View {
                             .matchedGeometryEffect(id: "info", in: missionAnimation)
                     }
                     
-                    Text(item.rawValue)
+                    Text(item.stringValue())
                         .frame(maxWidth: .infinity/4, minHeight: 50)
                         .font(.subheadline)
                         .foregroundColor(selectedMission == item ? .black: .customMissionBarGray)
@@ -94,6 +95,7 @@ struct MissionView: View {
                     withAnimation(.easeInOut) {
                         self.selectedMission = item
                         self.selectedMissionCategory = .none
+                        missionViewModel.updateNowMissionForCategory(info: selectedMission, category: selectedMissionCategory)
                     }
                 }
             }
@@ -113,7 +115,7 @@ struct MissionView: View {
                     }
                     
                     if item == .none {
-                        Text(item.rawValue)
+                        Text(item.stringValue())
                             .foregroundColor(selectedMissionCategory == item ? .black: .customMissionGray)
                             .frame(maxWidth: 20, maxHeight: 20)
                             .padding(.horizontal)
@@ -129,6 +131,7 @@ struct MissionView: View {
                 .onTapGesture {
                     withAnimation(.easeInOut) {
                         self.selectedMissionCategory = item
+                        missionViewModel.updateNowMissionForCategory(info: selectedMission, category: selectedMissionCategory)
                     }
                 }
             }
@@ -141,12 +144,4 @@ struct MissionView_Previews: PreviewProvider {
     static var previews: some View {
         MissionView()
     }
-}
-
-func getCurrentTime() -> String {
-    let nowDate = Date()
-    var formatter = DateFormatter()
-    formatter.locale = Locale(identifier: "ko")
-    formatter.dateFormat = "M월 dd일"
-    return formatter.string(from: Date())
 }

--- a/G-3280/ViewModel/MissionViewModel.swift
+++ b/G-3280/ViewModel/MissionViewModel.swift
@@ -6,8 +6,83 @@
 //
 
 import Foundation
+import SwiftUI
 
 class MissionViewModel: ObservableObject {
+    @Published var nowMission: [Mission] = []
     
+    init() {
+        updateNowMissionForCategory(info: .today, category: .none)
+    }
     
+    func getCurrentTime() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko")
+        formatter.dateFormat = "M월 dd일"
+        return formatter.string(from: Date())
+    }
+    
+    func updateNowMissionForCategory(info: missionInfo, category: missionCategory) {
+        switch (info, category) {
+        case (.today, .none):
+            // 일일미션
+            nowMission = missionData.filter { mission in
+                mission.type == info.rawValue
+            }
+        case (.week, .none):
+            // 주간 미션
+            nowMission = missionData.filter { mission in
+                mission.type == info.rawValue
+            }
+        case (.today, .water):
+            // 물 아껴쓰기 미션 중 오늘 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.week, .water):
+            // 물 아껴쓰기 미션 중 주간 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.today, .food):
+            // 음식물 쓰래기 줄이기 미션 중 오늘 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.week, .food):
+            // 음식물 쓰래기 줄이기 미션 중 주간 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.today, .electricity):
+            // 전기 아껴쓰기 미션 중 오늘 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.week, .electricity):
+            // 전기 아껴쓰기 미션 중 주간 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.today, .recycle):
+            // 분리수거 잘하기 미션 중 오늘 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        case (.week, .recycle):
+            // 분리수거 잘하기 미션 중 주간 수행해야 할 미션들
+            nowMission = missionData.filter { mission in
+                mission.category == category.rawValue && mission.type == info.rawValue
+            }
+        }
+    }
+//    func updateMissionData(info: missionInfo, category: missionCategory) {
+//        let missions = missionData.filter{ $0.type == info.stringValue() && $0.category == category.rawValue }
+//        self.nowMission = missions
+//    }
+    
+//    func getCategoryMissionData(category: String) -> [Mission] {
+//        let missions = missionData.filter { $0.category == category }
+//        return missions
+//    }
 }


### PR DESCRIPTION
## ✨ 해결한 이슈 
#25 

<br>

## 🛠️ 작업내용
- MissionView 에 현재 월, 일을 표시하도록 구현
- 더미 데이터를 통해 선택한 옵션에 따른 mission 을 출력 

<br>

|ScreenShot|
|------|
|![Simulator_Screen_Recording_-_iPhone_14_Pro_-_2023-05-22_at_22_24_03_AdobeExpress](https://github.com/G-3280/iOS_SwiftUI/assets/45564605/336ff88e-b5e5-43cc-93aa-57fa8cf96f1a)|

### ❗️ 자세한 설명

**선택한 옵션에 맞는 mission 출력하기**

선택할 수 있는 mission 에 대한 옵션은 일일, 주간 에 대한 옵션, 각 미션 주제에 대한 4개의 카테고리 옵션이 존재합니다
이렇게 많은 옵션 경우의 수를 어떻게 구현을 하면 더 효과적으로 가독성 있게 작성할 수 있을까 고민이 많았습니다

<br>

1. 일일, 주간 옵션에 대한 함수, 카테고리에 대한 옵션 에 대한 2개의 함수를 구현

각 옵션에 따른 함수를 분리 했을 때 어떤 작업을 하는지 정확히 알 수 있지만 2개로 나눠진다는 점과 미션 주제에 대한 옵션을 처리하기 위해선 항상 일일인지 주간인지 확인해야한다는 점입니다

즉, 어떤 상황이던간에 일일, 주간 옵션에 대한 함수를 실행하거나 같은 동작을 하는 로직을 각 함수마다 추가를 해야한다는 점입니다

<br>

2. `if - else` 구문을 통해 처리

첫번째 방법보다 하나의 함수로 처리가 가능해고 코드도 짧아졌습니다
하지만 여러개의 조건으로 인해 `if - else` 구문이 많아졌고 해당 조건이 어떠한 내용인지 한번에 알기 어려워졌습니다

<br>

3. `switch` 구문을 통해 처리

`if - else` 구문과 달리 코드의 양은 많아졌지만 `case` 구문에 어떤 옵션인지 정확히 적혀있어 해당 조건이 어떤 내용인지 한번에 알수 있게 되었습니다

코드의 양이 많아져 좋은 코드일까 라는 생각이 많았지만 다른 사람이 보기에도 읽기 좋은 코드가 더 좋다 생각하여 `switch` 구문을 선택하게 되었습니다

<br>

## 📋 추후 진행 상황
- 실제로 유저가 갖고 있는 미션을 불러와 출력하는 로직을 구현합니다

<br>

## 📌 리뷰 포인트
- 선택한 옵션에 맞는 mission 이 출력되는지 확인해주세요

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
