### PR TITLE
[Feat]  MoreInfoView 에서 보여줄 User 정보를 Firestore 에서 불러오는 로직 구현

### DIFF
--- a/G-3280.xcodeproj/project.pbxproj
+++ b/G-3280.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		3F7C96B02A0E203100C10436 /* MissionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96AF2A0E203100C10436 /* MissionModel.swift */; };
 		3F7C96B22A0E3D7100C10436 /* MissionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96B12A0E3D7100C10436 /* MissionViewModel.swift */; };
 		3F7C96B42A0E3E1100C10436 /* MissionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7C96B32A0E3E1100C10436 /* MissionCardView.swift */; };
+		3F98CB562A28578200A9842D /* Loading.json in Resources */ = {isa = PBXBuildFile; fileRef = 3F98CB552A28578200A9842D /* Loading.json */; };
 		3FF9D4982A023CA500973C55 /* CharacterCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF9D4972A023CA500973C55 /* CharacterCardView.swift */; };
 /* End PBXBuildFile section */
 
@@ -48,7 +49,6 @@
 		3F04C14A2A110C4C00C49FE9 /* MissionProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionProgressViewStyle.swift; sourceTree = "<group>"; };
 		3F04C14C2A11DE8600C49FE9 /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		3F04C14E2A11E25100C49FE9 /* UserInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoViewModel.swift; sourceTree = "<group>"; };
-		3F2907322A1F277D006353BF /* Loading.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Loading.json; sourceTree = "<group>"; };
 		3F2907352A1F27D2006353BF /* NotFoundDataView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotFoundDataView.swift; sourceTree = "<group>"; };
 		3F2907372A1F2BB1006353BF /* NotFoundData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = NotFoundData.json; sourceTree = "<group>"; };
 		3F3147D729FF982700BAECFC /* EvaluationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationView.swift; sourceTree = "<group>"; };
@@ -73,6 +73,7 @@
 		3F7C96AF2A0E203100C10436 /* MissionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionModel.swift; sourceTree = "<group>"; };
 		3F7C96B12A0E3D7100C10436 /* MissionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionViewModel.swift; sourceTree = "<group>"; };
 		3F7C96B32A0E3E1100C10436 /* MissionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissionCardView.swift; sourceTree = "<group>"; };
+		3F98CB552A28578200A9842D /* Loading.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Loading.json; sourceTree = "<group>"; };
 		3FF9D4972A023CA500973C55 /* CharacterCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterCardView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -96,7 +97,7 @@
 		3F2907312A1F2767006353BF /* Lottie */ = {
 			isa = PBXGroup;
 			children = (
-				3F2907322A1F277D006353BF /* Loading.json */,
+				3F98CB552A28578200A9842D /* Loading.json */,
 				3F2907372A1F2BB1006353BF /* NotFoundData.json */,
 				3F4B9F972A04EB3300E6AD03 /* LottieView.swift */,
 				3F4B9F9B2A04EB6200E6AD03 /* LoadingView.swift */,
@@ -267,6 +268,7 @@
 				3F7C968D2A0790F100C10436 /* GoogleService-Info.plist in Resources */,
 				3F61AAD629FE397900AABC4D /* Assets.xcassets in Resources */,
 				3F2907382A1F2BB1006353BF /* NotFoundData.json in Resources */,
+				3F98CB562A28578200A9842D /* Loading.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/G-3280/Lottie/NotFoundDataView.swift
+++ b/G-3280/Lottie/NotFoundDataView.swift
@@ -13,7 +13,7 @@ struct NotFoundDataView: View {
             Color.customBackGray
                 .edgesIgnoringSafeArea(.all)
             VStack {
-                LottieView(lottieFile: "NotFoundData", loopMode: .loop, speed: 1.8)
+                LottieView(lottieFile: "NotFoundData", loopMode: .playOnce, speed: 1.8)
                     .frame(width:200, height: 200)
                     .toolbar(.hidden)
                 

--- a/G-3280/Model/UserModel.swift
+++ b/G-3280/Model/UserModel.swift
@@ -24,6 +24,8 @@ struct UserModel: Identifiable, Codable {
     var completedMission: Int
     var completedCard: [String]
     var completedEvaluation: Int
+    var nowCompletedMissionCount: Int
+    var nowTotalMissionCount: Int
     // 필요한 다른 필드를 여기에 추가하세요.
 
     init?(id: String? = nil, data: [String: Any]) {
@@ -32,7 +34,9 @@ struct UserModel: Identifiable, Codable {
             let nickName = data["userName"] as? String,
             let completedMission = data["completedMission"] as? Int,
             let completedCard = data["completedCard"] as? [String],
-            let completedEvaluation = data["completedEvaluation"] as? Int
+            let completedEvaluation = data["completedEvaluation"] as? Int,
+            let nowCompletedMissionCount = data["nowCompletedMissionCount"] as? Int,
+            let nowTotalMissionCount = data["nowTotalMissionCount"] as? Int
         else {
             return nil
         }
@@ -44,5 +48,7 @@ struct UserModel: Identifiable, Codable {
         self.completedMission = completedMission
         self.completedCard = completedCard
         self.completedEvaluation = completedEvaluation
+        self.nowCompletedMissionCount = nowCompletedMissionCount
+        self.nowTotalMissionCount = nowTotalMissionCount
     }
 }

--- a/G-3280/View/MoreInfoView.swift
+++ b/G-3280/View/MoreInfoView.swift
@@ -12,8 +12,8 @@ struct MoreInfoView: View {
     @EnvironmentObject var userInfoViewModel: UserInfoViewModel
     @EnvironmentObject var authViewModel : AuthViewModel
     
-    @State var nowMissionCount: Double = 20
-    @State var totalMissionCount: Double = 20
+    @State var nowMissionCount: Double = 0
+    @State var totalMissionCount: Double = 0
     
     var body: some View {
         ZStack {
@@ -50,8 +50,16 @@ struct MoreInfoView: View {
             }
             .clipped()
             .padding(.top, 15)
+            .refreshable {
+                Task {
+                    await userInfoViewModel.fetchUser()
+                    self.nowMissionCount = Double(userInfoViewModel.user?.nowCompletedMissionCount ?? 0)
+                    self.totalMissionCount = Double(userInfoViewModel.user?.nowTotalMissionCount ?? 0)
+                }
+            }
             .onAppear {
-                //            print(viewModel.isLoggedIn)
+                self.nowMissionCount = Double(userInfoViewModel.user?.nowCompletedMissionCount ?? 0)
+                self.totalMissionCount = Double(userInfoViewModel.user?.nowTotalMissionCount ?? 0)
             }
         }
     }
@@ -143,7 +151,7 @@ struct MoreInfoView: View {
                     .font(.title3)
                     .fontWeight(.bold)
                     .padding(.bottom, 20)
-                    .padding(.leading, -15)
+                    .padding(.leading, -5)
  
                 HStack(spacing: 55) {
                     VStack {
@@ -153,7 +161,7 @@ struct MoreInfoView: View {
                             .frame(width: 54, height: 54)
                             .padding(.bottom, 15)
                         
-                        Text("10개")
+                        Text("\(Int(userInfoViewModel.user?.completedMission ?? 0))개")
                             .font(.title3)
                             .fontWeight(.bold)
                             .padding(.bottom, -3)
@@ -169,7 +177,7 @@ struct MoreInfoView: View {
                             .frame(width: 50, height:60)
                             .padding(.bottom, 9)
                         
-                        Text("5개")
+                        Text("\(Int(userInfoViewModel.user?.completedCard.count ?? 0))개")
                             .font(.title3)
                             .fontWeight(.bold)
                             .padding(.bottom, -3)
@@ -185,7 +193,7 @@ struct MoreInfoView: View {
                             .frame(width: 54, height: 54)
                             .padding(.bottom, 15)
                         
-                        Text("7개")
+                        Text("\(Int(userInfoViewModel.user?.completedEvaluation ?? 0))개")
                             .font(.title3)
                             .fontWeight(.bold)
                             .padding(.bottom, -3)

--- a/G-3280/ViewModel/MissionViewModel.swift
+++ b/G-3280/ViewModel/MissionViewModel.swift
@@ -65,8 +65,6 @@ class MissionViewModel: ObservableObject {
         } catch {
             print("Error occurred while fetching missions: \(error)")
         }
-        
-        
     }
     
     /// 상단에 위치한 현재 날짜보여주기 위해 시간을 받아오는 함수

--- a/G-3280/ViewModel/SignUpViewModel.swift
+++ b/G-3280/ViewModel/SignUpViewModel.swift
@@ -43,8 +43,10 @@ final class SignUpViewModel: ObservableObject {
                 "userEmail" : "\(email)",
                 "userName" : "\(nickname)",
                 "completedMission" : 0,
-                "completedCard" : ["penguin", "redPanda", "penguin"],
-                "completedEvaluation" : 0
+                "completedCard" : ["penguin", "redPanda", "marten"],
+                "completedEvaluation" : 0,
+                "nowCompletedMissionCount" : 0,
+                "nowTotalMissionCount" : 0
             ])
             
             print(result.user)

--- a/G-3280/ViewModel/UserInfoViewModel.swift
+++ b/G-3280/ViewModel/UserInfoViewModel.swift
@@ -12,6 +12,7 @@ class UserInfoViewModel: ObservableObject {
     @Published var user: UserModel?
     @Published var isLoading: Bool = false
     
+    
     private var db = Firestore.firestore()
 
     func fetchUser() async {


### PR DESCRIPTION
## ✨ 해결한 이슈 
#29

<br>

## 🛠️ 작업내용
- Firestore 의 users 컬렉션에 있는 user 정보를 로딩
- 불러온 데이터 중 미션 완료, 획득 카드, 평가 완료, 미션 진행 수 에 대한 count 를 MoreInfoView 와 연동

<br>

|ScreenShot|
|------|
|<img width="300" alt="스크린샷 2023-05-03 오전 10 30 04" src="https://github.com/G-3280/iOS_SwiftUI/assets/45564605/aaaae53b-5ab7-4475-b648-c518e99d1f68)">|

<br>

## 📋 추후 진행 상황
- Mission View 에서 미션을 완료 하면 FireStore 에 해당 미션을 true 로 변경
- 현재 촬영한 사진을 Firebase Storage 에 저장하기

<br>

## 📌 리뷰 포인트
- MoreInfoView 에서 데이터가 잘 출력되는지 확인해주세요

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
